### PR TITLE
ignored .vs directory (gitignore)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Debug and Release folder
 bin/
 obj/
+.vs/
 
 # Windows image file caches
 Thumbs.db


### PR DESCRIPTION
The .vs directory is a user specific Visual Studio directory and should be ignored.